### PR TITLE
GPU plan

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -125,7 +125,8 @@ const SERVER_PLANS = [
       { value: "8"},
       { value: "12"},
       { value: "16"},
-      { value: "24"}
+      { value: "24"},
+      { value: "56"}
     ]
   },
   {
@@ -231,6 +232,18 @@ const SERVER_PLANS = [
   }
 ]
 
+const GPUS =
+  [
+    {
+      name: "0",
+      value: "0"
+    },
+    {
+      name: "1",
+      value: "1"
+    }
+  ];
+
 
 /*!!!!!!!!!!!GLOBAL CONST END!!!!!!!!!!!*/
 
@@ -246,6 +259,7 @@ export default Ember.Component.extend(NodeDriver, {
   diskPlans:  DISK_PLANS,
   diskSizes: null,
   serverPlans: SERVER_PLANS,
+  gpus: GPUS,
   memorySizes: null,
 
   init() {
@@ -294,6 +308,7 @@ export default Ember.Component.extend(NodeDriver, {
       accessTokenSecret   : '',
       core                : '2',
       memory              : '4',
+      gpu                 : '0',
       osType              : 'coreos',
       diskSize            : '40',
       diskPlan            : 'ssd',
@@ -325,6 +340,9 @@ export default Ember.Component.extend(NodeDriver, {
     }
     if ( !get(this, 'config.memory') ) {
       errors.push('Memory is required');
+    }
+    if ( !get(this, 'config.gpu') ) {
+      errors.push('GPUs is required');
     }
     if ( !get(this, 'config.diskPlan') ) {
       errors.push('DiskPlan is required');

--- a/component/template.hbs
+++ b/component/template.hbs
@@ -42,7 +42,7 @@
       </div>
 
       <div class="row">
-        <div class="col span-6">
+        <div class="col span-4">
           <label class="acc-label">CPUs</label>
           <div class="input-group">
             {{new-select classNames="form-control" content=serverPlans optionLabelPath='core' optionValuePath='core' value=config.core}}
@@ -50,12 +50,17 @@
           </div>
         </div>
 
-        <div class="col span-6">
+        <div class="col span-4">
           <label class="acc-label">Memory</label>
           <div class="input-group">
             {{new-select classNames="form-control" content=memorySizes optionLabelPath='value' optionValuePath='value' value=config.memory}}
             <div class="input-group-addon bg-default">GB</div>
           </div>
+        </div>
+
+        <div class="col span-4">
+          <label class="acc-label">GPUs</label>
+          {{new-select classNames="form-control" content=gpus optionLabelPath='name' optionValuePath='value' value=config.gpu}}
         </div>
       </div>
 


### PR DESCRIPTION
GPUプランを選択可能にするために、select`GPUs`を追加。
現在は以下の条件の時のみGPUが利用可能。

- zone: is1a
- cpu: 4
- memory: 56
- gpu: 1

現在は上記の整合性の確認は行っていない。この辺りのバリデーションをどうするかの検討/対応は後続PRで行う。

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/1644816/136513733-245f6b89-f5fb-441a-8fbd-474e1c73fc74.png">